### PR TITLE
Fix French translations and descriptions

### DIFF
--- a/docs/fr/developer-guide/api/map.md
+++ b/docs/fr/developer-guide/api/map.md
@@ -602,7 +602,7 @@ Déclenché lorsqu'un dispositif de pointage (généralement une souris) est dé
 
 ### **`mouseout`**
 
-Déclenché lorsqu'un dispositif de pointage (généralement une souris) quitte la couche de la carte.
+Déclenché lorsqu'un dispositif de pointage (généralement une souris) quitte le canevas de la carte.
 
 **Type** [`MapMouseEvent`](https://docs.mapbox.com/mapbox-gl-js/api/events/#mapmouseevent)
 

--- a/docs/fr/developer-guide/api/map.md
+++ b/docs/fr/developer-guide/api/map.md
@@ -602,7 +602,7 @@ Déclenché lorsqu'un dispositif de pointage (généralement une souris) est dé
 
 ### **`mouseout`**
 
-Déclenché lorsqu'un dispositif de pointage (généralement une souris) quitte le canevas de la carte.
+Déclenché lorsqu'un dispositif de pointage (généralement une souris) quitte la couche de la carte.
 
 **Type** [`MapMouseEvent`](https://docs.mapbox.com/mapbox-gl-js/api/events/#mapmouseevent)
 

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -11,7 +11,7 @@ features:
   details: Utilise les mêmes couleurs de lignes que les plans officiels, avec des décalages adaptés au niveau de zoom
 - title: Opérabilité et performances
   details: Plus de 2 200 trains circulent simultanément avec une animation très fluide, même sur smartphone
-- title: Prise en charge de multilingue
+- title: Prise en charge multilingue
   details: En plus du japonais, Mini Tokyo 3D prend en charge l'anglais, le français, le chinois (simplifié et traditionnel) et le coréen
 - title: Vues aériennes et souterraines
   details: Facilite la lecture grâce au basculement entre réseaux ferroviaires aériens et souterrains


### PR DESCRIPTION
This pull request makes minor improvements to the French documentation by clarifying the description of a map event and correcting a feature title for better readability.

- Terminology correction:
  * In `docs/fr/developer-guide/api/map.md`, the description for the `mouseout` event "le canevas" was corrected to "la couche" for proper French usage and following the word for canvas in the documentation..

- Terminology correction:
  * In `docs/fr/index.md`, the feature title "Prise en charge de multilingue" was corrected to "Prise en charge multilingue" for proper French usage.