### PR TITLE
feat: Add direction arrow on train car top face

### DIFF
--- a/src/gpgpu/compute-fragment.glsl
+++ b/src/gpgpu/compute-fragment.glsl
@@ -142,6 +142,12 @@ void main() {
     rotateZ = fadingOut ? prevRotateZ : rotateZ;
     rotateX = fadingOut ? prevRotateX : rotateX;
 
+    // Flip rotation for trains running in reverse direction
+    if ( ! fadingOut && sectionDistance > nextSectionDistance ) {
+        rotateZ += 3.141592653589793;
+    }
+
+
     outPosition0 = vec4( position, float( colorID ) );
     outPosition1 = vec4( rotateZ, rotateX, opacityAnimationStartTime, opacity );
 }

--- a/src/mesh-set/color-vertex.glsl
+++ b/src/mesh-set/color-vertex.glsl
@@ -35,3 +35,8 @@ vInstanceColor = color0;
 #endif
 
 vInstanceOpacity = opacity0;
+
+#ifdef CAR
+vLocalNormalZ = normal.z;
+vUv2 = uv;
+#endif

--- a/src/mesh-set/common-fragment.glsl
+++ b/src/mesh-set/common-fragment.glsl
@@ -2,3 +2,8 @@
 
 varying vec3 vInstanceColor;
 varying float vInstanceOpacity;
+
+#ifdef CAR
+varying float vLocalNormalZ;
+varying vec2 vUv2;
+#endif

--- a/src/mesh-set/common-vertex.glsl
+++ b/src/mesh-set/common-vertex.glsl
@@ -41,3 +41,8 @@ mat3 rotateZ( float angle ) {
 
 varying vec3 vInstanceColor;
 varying float vInstanceOpacity;
+
+#ifdef CAR
+varying float vLocalNormalZ;
+varying vec2 vUv2;
+#endif

--- a/src/mesh-set/diffuse-color-fragment.glsl
+++ b/src/mesh-set/diffuse-color-fragment.glsl
@@ -1,1 +1,24 @@
 vec4 diffuseColor = vec4( diffuse * vInstanceColor, opacity * vInstanceOpacity );
+
+#ifdef CAR
+// Draw chevron arrow on top face (local normal Z+), near the front (high vUv2.y)
+if ( vLocalNormalZ > 0.5 ) {
+    float u = vUv2.x;
+    float v = vUv2.y; // 1.0 = front, 0.0 = back
+
+    float tip = 0.92;
+    float base = 0.72;
+    float hw = 0.3;
+    float thick = 0.1;
+
+    if ( v > base && v < tip ) {
+        float t = ( v - base ) / ( tip - base );
+        float outer = hw * ( 1.0 - t );
+        float inner = max( outer - thick, 0.0 );
+        float du = abs( u - 0.5 );
+        if ( du < outer && du > inner ) {
+            diffuseColor.rgb = mix( diffuseColor.rgb, vec3( 1.0 ), 0.5 );
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Closes #41

## What this PR does

Adds a chevron arrow indicator on the top face of train cars to show the direction of travel at a glance.

### Changes

**Arrow rendering (fragment shader)**
- `diffuse-color-fragment.glsl`: Draws a semi-transparent white chevron on the top face (detected via local normal Z) near the front edge (high UV.y)

**Passing data to fragment shader (vertex shaders)**
- `common-vertex.glsl` / `common-fragment.glsl`: Added LocalNormalZ and Uv2 varyings (CAR only)
- `color-vertex.glsl`: Assigns local normal Z and UV values to varyings

**Fix reverse-direction trains (compute shader)**
- `compute-fragment.glsl`: Flips `rotateZ` by π when `sectionDistance > nextSectionDistance`, so the geometry's Y+ axis always points in the actual direction of travel

### No changes to
- Car geometry shape (remains rectangular)
- Other vehicle types (aircraft, bus)
<img width="542" height="536" alt="image" src="https://github.com/user-attachments/assets/96750688-e199-46bf-a512-b494339b24d1" />