### PR TITLE
fix: skip stop_times rows with invalid departure_time

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -301,6 +301,9 @@ class StopTimeReader {
             me.stopSequenceIndex = fileds.indexOf('stop_sequence');
             me.stopHeadsignIndex = fileds.indexOf('stop_headsign');
         } else {
+            const departureOffset = getTimeOffset(fileds[me.departureTimeIndex]);
+            if (!Number.isFinite(departureOffset)) return;
+
             const id = fileds[me.tripIdIndex];
             let stopTimes;
 
@@ -311,7 +314,7 @@ class StopTimeReader {
                 lookup.set(id, stopTimes);
             }
             stopTimes.push([
-                getTimeOffset(fileds[me.departureTimeIndex]),
+                departureOffset,
                 fileds[me.stopIdIndex],
                 +fileds[me.stopSequenceIndex],
                 fileds[me.stopHeadsignIndex]


### PR DESCRIPTION
## Summary
When parsing GTFS `stop_times.txt`, rows with missing or invalid `departure_time` produced `NaN` in `departureTimes`, which broke timetable parsing in the web worker.

This change skips those rows early in `StopTimeReader.read()`.

## Motivation
Our GTFS feeds include `stop_times` for stops on the route where the vehicle does not stop (no boarding/alighting). For those rows we export `departure_time` as empty.

In the mini-tokyo-3d worker, an empty `departure_time` parses to `NaN`. Without a guard, that value is still written into the trip timetable; protobuf encodes `NaN` as `0`, and the UI renders offset `0` as `03:00` (start of the GTFS service day). That makes non-stopping stops look like departures at 3am.

Skip `stop_times` rows whose `departure_time` does not parse to a finite offset.
